### PR TITLE
編集および削除機能を追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,10 +6,9 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
   end
-
+  # 投稿の作成
   def create
     @post = current_user.posts.build(post_params)
-    logger.debug(params.inspect)
     if @post.save
       flash[:success] = "投稿に成功しました"
       redirect_to posts_path
@@ -18,8 +17,24 @@ class PostsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-
+  # 投稿の詳細
   def show
+    @post = Post.find(params[:id])
+  end
+  # 投稿の編集を登録するもの
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      flash[:success] = "投稿の編集に成功しました"
+      redirect_to posts_path(@post)
+    else
+      flash.now[:danger] = "投稿の編集に失敗しました。エラーメッセージを確認してください"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+  # 投稿の編集ページを表示
+  def edit
+    @post = current_user.posts.find(params[:id])
   end
 
   def destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
 
   has_many :posts, dependent: :destroy
+
+  def own?(object)
+    id == object&.user_id
+  end
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,26 @@
+<!-- 投稿編集ページ　-->
+<div>
+  <div class="flex">
+    <h1 class="text-2xl p-10 ">投稿編集</h1>
+    <div class="pt-10 pl-4 rounded-lg ml-20">
+      <%= form_with model: @post do |f| %>
+      <!-- タイトル -->
+      <div class="mb-4">
+        <%= f.label :title, "タイトル", class: "text-2xl block mb-6" %> 
+        <%= f.text_field :title, class: 'border  w-[440px] h-[40px]' %>
+      </div>
+      
+      <!-- 本文 -->
+      <div class="mb-4">
+        <%= f.label :body, "本文", class: "text-2xl block mb-6" %> 
+        <%= f.text_area :body, class: 'border  w-[780px] h-[140px]' %>
+      </div>
+      
+      <!-- 編集ボタン -->
+      <div class="mb-4 flex justify-center">
+        <%= f.submit "編集", class: 'hover:bg-green-500 transition-all duration-300 w-[110px] h-[80p] py-2 bg-green-600 text-white rounded-md ' %>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,7 +29,7 @@
         <div class="flex flex-col h-full">
           <!-- postタイトル -->
           <h2 class="font-semibold text-black text-xl mb-2 hover:text-white">
-            <%= link_to post.title, '#' %>
+            <%= link_to post.title, post_path(post)  %>
             <!-- ユーザーの名前 -->
             <span class="text-sm text-gray-800 ml-2"><%= post.user.first_name %><%= post.user.last_name %></span>
           </h2>
@@ -42,12 +42,15 @@
           <!-- 投稿日時を下に表示 -->
           <div class="flex justify-between items-center mt-auto">
             <p class="text-xs text-gray-500">投稿日: <%= post.created_at.strftime('%Y-%m-%d %H:%M') %></p>
-            <div class="flex space-x-3 ">
-              <!-- 編集ボタン -->
-              <%= link_to '編集', '#', class: 'text-blue-500 hover:text-blue-700' %>
-              <!-- 削除ボタン -->
-              <%= link_to '削除', post_path(post), data: {turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-red-500 hover:text-red-700' %>
-            </div>
+            <!-- ユーザーが自分ではない場合、編集と削除ボタンを表示させない仕組みに -->
+            <% if current_user.own?(post) %>
+              <div class="flex space-x-3 ">
+                <!-- 編集ボタン -->
+                <%= link_to '編集', edit_post_path(post), class: 'text-blue-500 hover:text-blue-700' %>
+                <!-- 削除ボタン -->
+                <%= link_to '削除', post_path(post), data: {turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-red-500 hover:text-red-700' %>
+              </div>
+            <% end %>
           </div>
         </div>  
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :posts, only: %i[index new create destroy show]
+  resources :posts, only: %i[index new create destroy show edit update]
   root "top_pages#top"
 
   # ユーザ登録のルーティング


### PR DESCRIPTION
Closes #27
Closes #28
# 編集機能と削除機能を追加した
作成したユーザーではない場合
編集と削除ボタンを表示できないように
userモデルに 
```
# own?メゾットで自分が投稿したものだけを識別
  def own?(object)
    id == object&.user_id
  end
```
を追加し
### index.htmlに
```
<!-- ユーザーが自分ではない場合、編集と削除ボタンを表示させない仕組みに -->
            <% if current_user.own?(post) %>
              <div class="flex space-x-3 ">
                <!-- 編集ボタン -->
                <%= link_to '編集', edit_post_path(post), class: 'text-blue-500 hover:text-blue-700' %>
                <!-- 削除ボタン -->
                <%= link_to '削除', post_path(post), data: {turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-red-500 hover:text-red-700' %>
              </div>
            <% end %>
```
を追加した