### PR TITLE
letter_opener_webのinitializersを訂正

### DIFF
--- a/config/initializers/letter_opener_web.rb
+++ b/config/initializers/letter_opener_web.rb
@@ -1,5 +1,8 @@
-Rails.application.config.to_prepare do
-  LetterOpenerWeb::LettersController.class_eval do
-    skip_before_action :verify_authenticity_token
+if Rails.env.development? || Rails.env.test?
+  Rails.application.config.to_prepare do
+    LetterOpenerWeb::LettersController.class_eval do
+      skip_before_action :verify_authenticity_token
+    end
   end
 end
+

--- a/config/initializers/letter_opener_web.rb
+++ b/config/initializers/letter_opener_web.rb
@@ -5,4 +5,3 @@ if Rails.env.development? || Rails.env.test?
     end
   end
 end
-


### PR DESCRIPTION
initializersに開発・テスト環境のときだけLetterOpenerWeb関連のコードが読み込まれるように記述