### PR TITLE
carrierwaveの変更

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,8 +8,6 @@ CarrierWave.configure do |config|
     # config.fog_provider = "fog/aws"
     config.fog_directory  = ENV["S3_BUCKET_NAME"]
     config.fog_public = true
-    # public-read ACLをつけるもの
-    config.fog_attributes = { "x-amz-acl" => "public-read" }
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY_ID"],


### PR DESCRIPTION
## やったこと

* carrrierwave.rbにある記述を削除。Amazon S3ではAclが無効となっているため、送ってしまうとエラーになるため。

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 無し

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 無し

## その他

* 無し
