### PR TITLE
golfgear.uploaderの修正

### DIFF
--- a/app/uploaders/golf_gear_image_uploader.rb
+++ b/app/uploaders/golf_gear_image_uploader.rb
@@ -13,7 +13,7 @@ class GolfGearImageUploader < CarrierWave::Uploader::Base
   process convert: "jpg"
 
   # アップロードされた画像を全て　800x400に変換
-  process resize_to_fill: [ 800, 400 ]
+  process resize_to_fit: [ 800, 400 ]
 
 
   # Override the directory where uploaded files will be stored.


### PR DESCRIPTION
## やったこと

* ゴルフギアの写真が表示されなかったので、Amazon S3側でバケットポリシーを変更した。
* ゴルフギアの写真が見切れてしまうのでresize_to_fillからresize_to_fitに変更

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* ゴルフギアの写真を投稿できる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 無し

## その他

* 無し
