### PR TITLE
登録されているEmailにgoogle認証を自動に

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -5,34 +5,34 @@ class OauthsController < ApplicationController
     login_at(auth_params[:provider])
   end
   # 先に保存されているアカウントがある場合自動でgoogle認証に登録する
-def callback
-  provider = auth_params[:provider]
+  def callback
+    provider = auth_params[:provider]
 
-  if (@user = login_from(provider))
-    redirect_to root_path, notice: "#{provider.titleize}アカウントでログインしました" and return
-  end
-
-  begin
-    sorcery_fetch_user_hash(provider)
-    email = @user_hash[:email] || @user_hash["email"]
-    uid   = @user_hash[:uid]   || @user_hash["uid"]
-
-    if (existing = User.find_by(email: email))
-      existing.authentications.find_or_create_by!(provider: provider, uid: uid)
-      reset_session
-      auto_login(existing)
+    if (@user = login_from(provider))
       redirect_to root_path, notice: "#{provider.titleize}アカウントでログインしました" and return
     end
 
-    @user = create_from(provider)
-    reset_session
-    auto_login(@user)
-    redirect_to root_path, notice: "#{provider.titleize}アカウントでログインしました"
-  rescue => e
-    Rails.logger.warn("[OAuth] failed: #{e.class} #{e.message}")
-    redirect_to root_path, alert: "#{provider.titleize}アカウントでのログインに失敗しました"
+    begin
+      sorcery_fetch_user_hash(provider)
+      email = @user_hash[:email] || @user_hash["email"]
+      uid   = @user_hash[:uid]   || @user_hash["uid"]
+
+      if (existing = User.find_by(email: email))
+        existing.authentications.find_or_create_by!(provider: provider, uid: uid)
+        reset_session
+        auto_login(existing)
+        redirect_to root_path, notice: "#{provider.titleize}アカウントでログインしました" and return
+      end
+
+      @user = create_from(provider)
+      reset_session
+      auto_login(@user)
+      redirect_to root_path, notice: "#{provider.titleize}アカウントでログインしました"
+    rescue => e
+      Rails.logger.warn("[OAuth] failed: #{e.class} #{e.message}")
+      redirect_to root_path, alert: "#{provider.titleize}アカウントでのログインに失敗しました"
+    end
   end
-end
 
   private
 


### PR DESCRIPTION
## やったこと

* 登録されているユーザー情報がある状態でgoogle認証を行った場合、自動でgoogle認証と連携されるようにした。

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 自動でユーザーが登録され、google認証でログインできるようになる。

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 無し

## その他

* 無し
